### PR TITLE
Sidebar Section Alternative Language Key

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -162,6 +162,18 @@ render_quarto_lang <- function(language_code, path, output_dir, type) {
 
   if (type == "website") {
 
+    # Update sidebar section titles for the current language
+    if (!is.null(config$website$sidebar$contents)) {
+      for (i in seq_along(config$website$sidebar$contents)) {
+        if (is.list(config$website$sidebar$contents[[i]])) {
+          section_key <- paste0("section-", language_code)
+          if (!is.null(config$website$sidebar$contents[[i]][[section_key]])) {
+            config$website$sidebar$contents[[i]]$section <- config$website$sidebar$contents[[i]][[section_key]]
+          }
+        }
+      }
+    }
+
     # only keep what's needed
     qmds <- fs::dir_ls(
       file.path(temporary_directory, fs::path_file(path)),


### PR DESCRIPTION
Checks if there is an alternative language key for the sidebar section. If there are then, switch them out when switching to designated language. Here is an example of what it would look like in the _quarto.yaml

```
sidebar:
    style: "docked"
    logo: "can_wm.png"
    collapse-level: 1
    contents:
      - index.qmd
      - section: "Available Data"
        section-fr: "Available Data (fr)"
        contents:
          - cwfis_datasets.qmd
          - cwfis_map.qmd
          - cwfis_geoserver.qmd
      - usage.qmd
      - section: "Past Map Images"
        section-fr: "Past Map Images (fr)"
        contents:
          - map_images_m3.qmd
          - map_images_fwi.qmd
          - map_images_fbp.qmd
          - map_images_weather.qmd
      - section: "Access Geoserver Layers"
        section-fr: "Access Geoserver Layers (fr)"
        contents:
          - layer_wms.qmd
          - layer_wfs.qmd
          - layer_wcs.qmd
      - section: "Plot Maps in Python"
        section-fr: "Plot Maps in Python (fr)"
        contents:
          - tutorial_python_wms.qmd
          - tutorial_python_wfs.qmd
```